### PR TITLE
Add keydown event listener to the TradingView chart object

### DIFF
--- a/hotkeys/topstepx.hotkeys.pagemanipulator.bootstrap.js
+++ b/hotkeys/topstepx.hotkeys.pagemanipulator.bootstrap.js
@@ -116,7 +116,9 @@ fetch('https://raw.githubusercontent.com/cargocultscience/topstepx/main/hotkeys/
 
     // move stop to break even
     {"keys" : ["alt", "ctrl", "keye"], "f" : () => buttonClickStopBreakEven()},
-
+  
+    // debug mode
+    {"keys" : ["alt", "ctrl", "keyd"], "f" : () => toggleDebug()},
 ];
 setupHotkeys(accounts);
 });

--- a/hotkeys/topstepx.hotkeys.pagemanipulator.js
+++ b/hotkeys/topstepx.hotkeys.pagemanipulator.js
@@ -1,6 +1,6 @@
 function hotkeysVersion()
 {
-    return "4.2.5";
+    return "4.2.6";
 }
 
 var debugHotkeys = false;

--- a/hotkeys/topstepx.hotkeys.pagemanipulator.js
+++ b/hotkeys/topstepx.hotkeys.pagemanipulator.js
@@ -3,13 +3,20 @@ function hotkeysVersion()
     return "4.2.2";
 }
 
+function ondocloaded(event)
+{
+    console.log("ondocloaded");
+    console.log(Object.keys(document).filter(k => k.startsWith('tradingview')));
+}
 
 async function setupHotkeys(accounts) {
+    window.onloadeddata = ondocloaded;
     var hotkeysDict = {}
     console.log(hotkeys);
     hotkeys.forEach((m) => hotkeysDict[m["keys"].sort().join()] = m["f"])
         
     document.addEventListener('keydown',handleKeyDownDocument);
+    /*
     chartConnected = false;
     while(!chartConnected) {
         console.log("Trying to connect chart");
@@ -22,7 +29,7 @@ async function setupHotkeys(accounts) {
         }
         sleep(1000);
     }
-
+    */
     //document[Object.keys(document).filter(k => k.startsWith('tradingview'))[0]].addEventListener('keydown',handleKeyDownChart);
     console.log(Object.keys(document).filter(k => k.startsWith('tradingview')));
     function handleKeyDownChart(event) {

--- a/hotkeys/topstepx.hotkeys.pagemanipulator.js
+++ b/hotkeys/topstepx.hotkeys.pagemanipulator.js
@@ -3,12 +3,30 @@ function hotkeysVersion()
     return "4.1.2";
 }
 
+var chartConnected = false;
+
+async function tryChartListner()
+{
+}
+
 async function setupHotkeys(accounts) {
     var hotkeysDict = {}
     console.log(hotkeys);
     hotkeys.forEach((m) => hotkeysDict[m["keys"].sort().join()] = m["f"])
         
     document.addEventListener('keydown',handleKeyDownDocument);
+    while(!chartConnected) {
+        console.log("Trying to connect chart: " + chart);
+        chartArray = Object.keys(document).filter(k => k.startsWith('tradingview'));
+        if(chartArray.length > 0) {
+            chart = chartArray[0];
+            console.log("Connected chart: " + chart);
+            chartConnected = true;
+            chart.addEventListener('keydown', handleKeyDownChart);
+        }
+        sleep(250);
+    }
+
     //document[Object.keys(document).filter(k => k.startsWith('tradingview'))[0]].addEventListener('keydown',handleKeyDownChart);
     console.log(Object.keys(document).filter(k => k.startsWith('tradingview')));
     function handleKeyDownChart(event) {

--- a/hotkeys/topstepx.hotkeys.pagemanipulator.js
+++ b/hotkeys/topstepx.hotkeys.pagemanipulator.js
@@ -1,6 +1,6 @@
 function hotkeysVersion()
 {
-    return "4.2.3";
+    return "4.2.4";
 }
 
 async function setupHotkeys(accounts, hotkeys) {
@@ -14,15 +14,15 @@ async function setupHotkeys(accounts, hotkeys) {
         console.log("Trying to connect chart");
         chartArray = Object.keys(document).filter(k => k.startsWith('tradingview'));
         if(chartArray.length > 0) {
-            chart = chartArray[0];
-            console.log("Connected chart: " + chart);
+            chartName = chartArray[0];
+            chart = document[chartName];
+            console.log("Connected chart: " + chartName);
             chartConnected = true;
             chart.addEventListener('keydown', handleKeyDownChart);
         }
         await sleep(250);
     }
-    
-    console.log(Object.keys(document).filter(k => k.startsWith('tradingview')));
+
     function handleKeyDownChart(event) {
         console.log("handle keydown chart");
         handleKeyDownCommon(event, "chart");

--- a/hotkeys/topstepx.hotkeys.pagemanipulator.js
+++ b/hotkeys/topstepx.hotkeys.pagemanipulator.js
@@ -4,12 +4,26 @@ function hotkeysVersion()
 }
 
 async function setupHotkeys(accounts) {
+    document.tradingview_0cbf3.addEventListener('keydown',handleKeyDown);
+    function handleKeyDown(event) { console.log(event) }
+
+
     var hotkeysDict = {}
     console.log(hotkeys);
     hotkeys.forEach((m) => hotkeysDict[m["keys"].sort().join()] = m["f"])
         
-    document.addEventListener('keydown',handleKeyDown);
-    function handleKeyDown(event) {
+    document.addEventListener('keydown',handleKeyDownDocument);
+    document[Object.keys(document).filter(k => k.startsWith('tradingview'))[0]].addEventListener('keydown',handleKeyDownChart);
+    
+    function handleKeyDownChart(event) {
+        handleKeyDownCommon(event, "chart");
+    }
+
+    function handleKeyDownDocument(event) {
+        handleKeyDownCommon(event, "document");
+    }
+    
+    function handleKeyDownCommon(event, source) {
         if(event.repeat == true) return;
         let eventKeySet = new Set();
         if(event.shiftKey)
@@ -34,7 +48,7 @@ async function setupHotkeys(accounts) {
         if(eventKey in hotkeysDict)
         {
             event.preventDefault();
-            console.log("Firing hotkey: " + eventKey)
+            console.log("Firing hotkey: " + eventKey + " from " + source);
             hotkeysDict[eventKey]();
         }
     }

--- a/hotkeys/topstepx.hotkeys.pagemanipulator.js
+++ b/hotkeys/topstepx.hotkeys.pagemanipulator.js
@@ -1,6 +1,6 @@
 function hotkeysVersion()
 {
-    return "4.0.1";
+    return "4.1.1";
 }
 
 async function setupHotkeys(accounts) {
@@ -20,6 +20,7 @@ async function setupHotkeys(accounts) {
     }
     
     function handleKeyDownCommon(event, source) {
+        console.log(event, source);
         if(event.repeat == true) return;
         let eventKeySet = new Set();
         if(event.shiftKey)

--- a/hotkeys/topstepx.hotkeys.pagemanipulator.js
+++ b/hotkeys/topstepx.hotkeys.pagemanipulator.js
@@ -10,8 +10,9 @@ async function setupHotkeys(accounts) {
         
     document.addEventListener('keydown',handleKeyDownDocument);
     document[Object.keys(document).filter(k => k.startsWith('tradingview'))[0]].addEventListener('keydown',handleKeyDownChart);
-    
+    console.log(Object.keys(document).filter(k => k.startsWith('tradingview'))[0])
     function handleKeyDownChart(event) {
+        console.log("handle keydown chart");
         handleKeyDownCommon(event, "chart");
     }
 

--- a/hotkeys/topstepx.hotkeys.pagemanipulator.js
+++ b/hotkeys/topstepx.hotkeys.pagemanipulator.js
@@ -5,7 +5,7 @@ function hotkeysVersion()
 
 var debugHotkeys = false;
 
-async function connectChart() {
+async function findChart() {
     // chart component may not be available on the moment the page is loaded so try in a loop
     for(var i = 0; i < 10; ++i) {    
         console.log("Trying to find chart object");

--- a/hotkeys/topstepx.hotkeys.pagemanipulator.js
+++ b/hotkeys/topstepx.hotkeys.pagemanipulator.js
@@ -16,7 +16,7 @@ async function setupHotkeys(accounts) {
         
     document.addEventListener('keydown',handleKeyDownDocument);
     while(!chartConnected) {
-        console.log("Trying to connect chart: " + chart);
+        console.log("Trying to connect chart");
         chartArray = Object.keys(document).filter(k => k.startsWith('tradingview'));
         if(chartArray.length > 0) {
             chart = chartArray[0];

--- a/hotkeys/topstepx.hotkeys.pagemanipulator.js
+++ b/hotkeys/topstepx.hotkeys.pagemanipulator.js
@@ -4,10 +4,6 @@ function hotkeysVersion()
 }
 
 async function setupHotkeys(accounts) {
-    document.tradingview_0cbf3.addEventListener('keydown',handleKeyDown);
-    function handleKeyDown(event) { console.log(event) }
-
-
     var hotkeysDict = {}
     console.log(hotkeys);
     hotkeys.forEach((m) => hotkeysDict[m["keys"].sort().join()] = m["f"])

--- a/hotkeys/topstepx.hotkeys.pagemanipulator.js
+++ b/hotkeys/topstepx.hotkeys.pagemanipulator.js
@@ -1,6 +1,6 @@
 function hotkeysVersion()
 {
-    return "4.1.2";
+    return "4.2.1";
 }
 
 var chartConnected = false;

--- a/hotkeys/topstepx.hotkeys.pagemanipulator.js
+++ b/hotkeys/topstepx.hotkeys.pagemanipulator.js
@@ -1,13 +1,8 @@
 function hotkeysVersion()
 {
-    return "4.2.1";
+    return "4.2.2";
 }
 
-var chartConnected = false;
-
-async function tryChartListner()
-{
-}
 
 async function setupHotkeys(accounts) {
     var hotkeysDict = {}
@@ -15,6 +10,7 @@ async function setupHotkeys(accounts) {
     hotkeys.forEach((m) => hotkeysDict[m["keys"].sort().join()] = m["f"])
         
     document.addEventListener('keydown',handleKeyDownDocument);
+    chartConnected = false;
     while(!chartConnected) {
         console.log("Trying to connect chart");
         chartArray = Object.keys(document).filter(k => k.startsWith('tradingview'));
@@ -24,7 +20,7 @@ async function setupHotkeys(accounts) {
             chartConnected = true;
             chart.addEventListener('keydown', handleKeyDownChart);
         }
-        sleep(250);
+        sleep(1000);
     }
 
     //document[Object.keys(document).filter(k => k.startsWith('tradingview'))[0]].addEventListener('keydown',handleKeyDownChart);

--- a/hotkeys/topstepx.hotkeys.pagemanipulator.js
+++ b/hotkeys/topstepx.hotkeys.pagemanipulator.js
@@ -1,6 +1,6 @@
 function hotkeysVersion()
 {
-    return "4.1.1";
+    return "4.1.2";
 }
 
 async function setupHotkeys(accounts) {
@@ -9,8 +9,8 @@ async function setupHotkeys(accounts) {
     hotkeys.forEach((m) => hotkeysDict[m["keys"].sort().join()] = m["f"])
         
     document.addEventListener('keydown',handleKeyDownDocument);
-    document[Object.keys(document).filter(k => k.startsWith('tradingview'))[0]].addEventListener('keydown',handleKeyDownChart);
-    console.log(Object.keys(document).filter(k => k.startsWith('tradingview'))[0])
+    //document[Object.keys(document).filter(k => k.startsWith('tradingview'))[0]].addEventListener('keydown',handleKeyDownChart);
+    console.log(Object.keys(document).filter(k => k.startsWith('tradingview')));
     function handleKeyDownChart(event) {
         console.log("handle keydown chart");
         handleKeyDownCommon(event, "chart");

--- a/hotkeys/topstepx.hotkeys.pagemanipulator.js
+++ b/hotkeys/topstepx.hotkeys.pagemanipulator.js
@@ -1,6 +1,6 @@
 function hotkeysVersion()
 {
-    return "4.2.6";
+    return "4.2.7";
 }
 
 var debugHotkeys = false;
@@ -28,18 +28,18 @@ async function setupHotkeys(accounts, hotkeys) {
     hotkeys.forEach((m) => hotkeysDict[m["keys"].sort().join()] = m["f"])
         
     document.addEventListener('keydown', (event) => handleKeyDown(event, 'document'));
-    var chart = findChart();
     
+    var chart = await findChart();
     if(chart) {
         chart.addEventListener('keydown', (event) => handleKeyDown(event, 'chart'));
     }
 
     function handleKeyDown(event, source) {
+        if(event.repeat == true) return;
         if(debugHotkeys)
         {
-            console.log("DEBUG: " + event);
+            console.log(event, source);
         }
-        if(event.repeat == true) return;
         let eventKeySet = new Set();
         if(event.shiftKey)
         {

--- a/hotkeys/topstepx.hotkeys.pagemanipulator.js
+++ b/hotkeys/topstepx.hotkeys.pagemanipulator.js
@@ -1,22 +1,14 @@
 function hotkeysVersion()
 {
-    return "4.2.2";
+    return "4.2.3";
 }
 
-function ondocloaded(event)
-{
-    console.log("ondocloaded");
-    console.log(Object.keys(document).filter(k => k.startsWith('tradingview')));
-}
-
-async function setupHotkeys(accounts) {
-    window.onloadeddata = ondocloaded;
+async function setupHotkeys(accounts, hotkeys) {
     var hotkeysDict = {}
     console.log(hotkeys);
     hotkeys.forEach((m) => hotkeysDict[m["keys"].sort().join()] = m["f"])
         
     document.addEventListener('keydown',handleKeyDownDocument);
-    /*
     chartConnected = false;
     while(!chartConnected) {
         console.log("Trying to connect chart");
@@ -27,10 +19,9 @@ async function setupHotkeys(accounts) {
             chartConnected = true;
             chart.addEventListener('keydown', handleKeyDownChart);
         }
-        sleep(1000);
+        await sleep(250);
     }
-    */
-    //document[Object.keys(document).filter(k => k.startsWith('tradingview'))[0]].addEventListener('keydown',handleKeyDownChart);
+    
     console.log(Object.keys(document).filter(k => k.startsWith('tradingview')));
     function handleKeyDownChart(event) {
         console.log("handle keydown chart");

--- a/hotkeys/topstepx.hotkeys.pagemanipulator.js
+++ b/hotkeys/topstepx.hotkeys.pagemanipulator.js
@@ -22,7 +22,7 @@ async function findChart() {
     return null;
 }
 
-async function setupHotkeys(accounts, hotkeys) {
+async function setupHotkeys(accounts) {
     var hotkeysDict = {}
     console.log(hotkeys);
     hotkeys.forEach((m) => hotkeysDict[m["keys"].sort().join()] = m["f"])


### PR DESCRIPTION
the TradingView chart object used by TopStepX must be consuming keydown events and not bubbling them back.  We must first find the chart object (which is on a delayed load) and then add an explicit keydown event handler.

Added a 'debug' toggle to log keydown events
